### PR TITLE
refactor: Simplify the `$_viewPath` using the alias

### DIFF
--- a/src/debug/EagerLoadingPanel.php
+++ b/src/debug/EagerLoadingPanel.php
@@ -23,7 +23,7 @@ class EagerLoadingPanel extends Panel
     /**
      * @var string
      */
-    private string $_viewPath = '@vendor/putyourlightson/craft-elements-panel/src/views/eager-loading/';
+    private string $_viewPath = '@putyourlightson/elementspanel/views/eager-loading/';
 
     /**
      * @inheritdoc
@@ -33,14 +33,13 @@ class EagerLoadingPanel extends Panel
         parent::init();
 
         Event::on(ElementQuery::class, ElementQuery::EVENT_BEFORE_PREPARE,
-            function(CancelableEvent $event) {
+            function (CancelableEvent $event) {
                 /** @var ElementQuery $elementQuery */
                 $elementQuery = $event->sender;
 
                 if ($elementQuery instanceof MatrixBlockQuery) {
                     $this->_checkMatrixRelations($elementQuery);
-                }
-                else {
+                } else {
                     $this->_checkBaseRelations($elementQuery);
                 }
             }


### PR DESCRIPTION
Every plugin has an alias automatically created for it by the plugin installer (it's stored in the `craftcms/plugins.php` file):

https://github.com/craftcms/plugin-installer/blob/master/src/Installer.php#L291

...which is set to the `src/` directory of the plugin (or whatever is defined in the PSR-4 namespace in the plugin's `composer.json`), and is set to `@vendor/pluginprettyname` or in this case, `@putyourlightson/elementspanel`

So might as well use it